### PR TITLE
Fixes #22: Only show the "no database installed" admin notice to admins.

### DIFF
--- a/init.php
+++ b/init.php
@@ -38,7 +38,7 @@ add_action('admin_init', 'geoip_detect_enqueue_admin_notices');
 
 function geoip_detect_admin_notice_database_missing() {
 	$ignored_notices = (array) get_user_meta(get_current_user_id(), 'geoip_detect_dismissed_notices', true);
-	if (in_array('hostinfo_used', $ignored_notices))
+	if (in_array('hostinfo_used', $ignored_notices) || !current_user_can('manage_options'))
 		return;
 
 	$url = '<a href="tools.php?page=' . GEOIP_PLUGIN_BASENAME . '">GeoIP Detection</a>';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -126,4 +126,19 @@ class WP_UnitTestCase_GeoIP_Detect extends WP_UnitTestCase
 		
 		$this->assertEquals($expected, $checkObject);
 	}
+
+    /**
+     * Empty method to disable integration with WP Core Trac.
+     *
+     * Overrides the parent's method to disable fetching information
+     * from the WordPress Core Trac ticket tracker which causes tests
+     * with the `@ticket` annotation in our own test cases to fail CI.
+     *
+     * @link https://core.trac.wordpress.org/browser/tags/4.4/tests/phpunit/includes/testcase.php#L434
+     *
+     * @return void
+     */
+    protected function checkRequirements () {
+        // do nothing!
+    }
 } 

--- a/tests/test-datasources.php
+++ b/tests/test-datasources.php
@@ -64,4 +64,29 @@ class DataSourcesTest extends WP_UnitTestCase_GeoIP_Detect {
 			$this->assertNotEmpty($desc, 'Description of "' . $id . '" missing.');
 		}
 	}
+
+    /**
+     * @group admin_notices
+     *
+     * @ticket 22
+     */
+    public function testAdminNoticeDatabaseMissingRequiresManageOptionsCapability () {
+        $id = $this->factory->user->create(array('role' => 'subscriber'));
+        wp_set_current_user($id);
+        $this->expectOutputString('');
+        geoip_detect_admin_notice_database_missing();
+    }
+
+    /**
+     * @group admin_notices
+     *
+     * @ticket 22
+     */
+    public function testAdminNoticeDatabaseMissingPrintsOutputWithManageOptionsCapability () {
+        $id = $this->factory->user->create(array('role' => 'administrator'));
+        wp_set_current_user($id);
+        $this->expectOutputRegex('/' . __('GeoIP Detection: No database installed', 'geoip-detect') . '/');
+        geoip_detect_admin_notice_database_missing();
+    }
+
 }

--- a/tests/test-datasources.php
+++ b/tests/test-datasources.php
@@ -71,7 +71,13 @@ class DataSourcesTest extends WP_UnitTestCase_GeoIP_Detect {
      * @ticket 22
      */
     public function testAdminNoticeDatabaseMissingRequiresManageOptionsCapability () {
-        $id = $this->factory->user->create(array('role' => 'subscriber'));
+        $args = array('role' => 'subscriber');
+        if (!$this->factory) {
+            $this->factory = new WP_UnitTest_Factory();
+            $args['user_login'] = hash('md5', uniqid() . microtime());
+            $args['user_email'] = hash('md5', uniqid() . microtime()) . '@example.invalid';
+        }
+        $id = $this->factory->user->create($args);
         wp_set_current_user($id);
         $this->expectOutputString('');
         geoip_detect_admin_notice_database_missing();
@@ -83,7 +89,13 @@ class DataSourcesTest extends WP_UnitTestCase_GeoIP_Detect {
      * @ticket 22
      */
     public function testAdminNoticeDatabaseMissingPrintsOutputWithManageOptionsCapability () {
-        $id = $this->factory->user->create(array('role' => 'administrator'));
+        $args = array('role' => 'administrator');
+        if (!$this->factory) {
+            $this->factory = new WP_UnitTest_Factory();
+            $args['user_login'] = hash('md5', uniqid() . microtime());
+            $args['user_email'] = hash('md5', uniqid() . microtime()) . '@example.invalid';
+        }
+        $id = $this->factory->user->create($args);
         wp_set_current_user($id);
         $this->expectOutputRegex('/' . __('GeoIP Detection: No database installed', 'geoip-detect') . '/');
         geoip_detect_admin_notice_database_missing();


### PR DESCRIPTION
This commit also adds a `checkRequirements()` method to the
`WP_UnitTestCase_GeoIP_Detect` class in order to ensure that Travis-CI
does not attempt to fetch WordPress Core Trac tickets when building.
This is done in order to make our own use of the `@ticket` annotation in
PHPUnit to refer to issues on GitHub.com.

This commit includes test cases for the bugfix.